### PR TITLE
UI improvement: Scroll bar on code containers when height exceeds 400px with "View All" button

### DIFF
--- a/LMLocal/Resources/css/app.css
+++ b/LMLocal/Resources/css/app.css
@@ -371,6 +371,33 @@ body {
         color: var(--success-color) !important;
     }
 
+/* Code block height restriction and expansion */
+.restrictCodeBlockHeight {
+    max-height: 400px;
+    overflow: auto;
+}
+
+/* "View All" button for expanding tall code blocks */
+.view-all-button {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    border-top: 1px solid var(--border-color);
+    border-radius: 0;
+    background: var(--code-header-bg);
+    color: var(--muted-color);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    transition: background 0.2s;
+}
+
+    .view-all-button:hover {
+        background: var(--input-bg);
+    }
+
 pre {
     padding: 6px !important;
     margin: 6px !important;

--- a/LMLocal/Resources/js/chat/ai.message.js
+++ b/LMLocal/Resources/js/chat/ai.message.js
@@ -1,4 +1,4 @@
-﻿import { attachCopyButton } from '@app/chat/attach.copy.button.js';
+﻿import { wrapCodeBlocks, attachCopyButton } from '@app/chat/attach.copy.button.js';
 /**
  * Factory that creates an message DOM element, caches its internal blocks,
  * and returns an API to manipulate the message.
@@ -89,6 +89,11 @@ export function createAiMessage(container, highlightWorkerClient, streamingPipel
             return new Promise((resolve) => {
                 streamingPipeline.onEnd(async () => {
                     element?.classList.add('completed');
+
+                    if (responseContainer?.isConnected) {
+                        wrapCodeBlocks(responseContainer);
+                    }
+
                     try {
                         await highlightWorkerClient.highlightContainer(responseContainer);
                     } catch (err) {

--- a/LMLocal/Resources/js/chat/attach.copy.button.js
+++ b/LMLocal/Resources/js/chat/attach.copy.button.js
@@ -1,6 +1,27 @@
 import { UIText, Assets } from '@app/store/app.globals.js';
 
 /**
+ * Wraps unprocessed `<pre>` blocks in `.code-block-container` divs.
+ * This creates the container structure needed by the highlight worker to add "View All" buttons
+ * and should be called before highlighting.
+ */
+export function wrapCodeBlocks(containerElem) {
+    if (!containerElem) return;
+    const preElements = containerElem.querySelectorAll('pre');
+    preElements.forEach(pre => {
+        if (pre.hasAttribute('data-code-wrapped')) return;
+        if (pre.closest('.code-block-container')) return;
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'code-block-container';
+        if (!pre.parentNode) return;
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+        pre.setAttribute('data-code-wrapped', 'true');
+    });
+}
+
+/**
  * Scans `containerElem` for `<pre><code>` blocks and attaches a copy header to each unprocessed block.
  */
 export function attachCopyButton(containerElem) {
@@ -8,7 +29,10 @@ export function attachCopyButton(containerElem) {
     const preElements = containerElem.querySelectorAll('pre');
     preElements.forEach(pre => {
         if (pre.hasAttribute('data-copy-processed')) return;
-        if (pre.closest('.code-block-container')) return;
+        const container = pre.closest('.code-block-container');
+        if (!container) return;
+        if (container.querySelector('.code-header')) return;
+
         const codeElement = pre.querySelector('code');
         if (!codeElement) return;
 
@@ -23,8 +47,6 @@ export function attachCopyButton(containerElem) {
             lang = 'text';
         }
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'code-block-container';
         const header = document.createElement('div');
         header.className = 'code-header';
         header.innerHTML = `
@@ -33,9 +55,8 @@ export function attachCopyButton(containerElem) {
                 ${Assets.COPY_BUTTON_SVG}
                 <span>${UIText.COPY_LABEL}</span>
             </button>`;
-        if (!pre.parentNode) return;
-        pre.parentNode.insertBefore(wrapper, pre);
-        wrapper.append(header, pre);
+
+        container.insertBefore(header, pre);
         pre.setAttribute('data-copy-processed', 'true');
     });
 }

--- a/LMLocal/Resources/js/workers/highlight/highlight.worker.client.js
+++ b/LMLocal/Resources/js/workers/highlight/highlight.worker.client.js
@@ -84,6 +84,54 @@ export class HighlightWorkerClient {
                     const errorInfo = res?.error;
                     console.warn('Highlighting failed for block:', block, errorInfo);
                 }
+
+                // If the code block exceeds 400px in height, restrict its max-height and add a "View All" button
+                if (block.scrollHeight > 400) {
+                    block.classList.add('restrictCodeBlockHeight');
+
+                    const container = block.closest('.code-block-container');
+                    if (!container) return;
+
+                    if (container.querySelector('.view-all-button')) return;
+
+                    const viewAllButton = document.createElement('button');
+                    viewAllButton.type = 'button';
+                    viewAllButton.textContent = 'View All';
+                    viewAllButton.className = 'view-all-button';
+                    viewAllButton.setAttribute('aria-expanded', 'false');
+
+                    // Generate a unique ID for accessibility if not already present
+                    if (!block.id) {
+                        block.id = `code-block-${Math.random().toString(36).slice(2, 9)}`;
+                    }
+                    viewAllButton.setAttribute('aria-controls', block.id);
+                    viewAllButton.setAttribute('aria-label', 'View all code');
+
+                    // Insert button after the <pre> element, inside the container
+                    const pre = block.parentElement;
+                    if (pre && pre.nextSibling) {
+                        pre.parentElement.insertBefore(viewAllButton, pre.nextSibling);
+                    } else if (pre) {
+                        pre.parentElement.appendChild(viewAllButton);
+                    } else {
+                        container.appendChild(viewAllButton);
+                    }
+
+                    let expanded = false;
+
+                    viewAllButton.addEventListener('click', () => {
+                        expanded = !expanded;
+                        viewAllButton.setAttribute('aria-expanded', String(expanded));
+
+                        if (expanded) {
+                            block.classList.remove('restrictCodeBlockHeight');
+                            viewAllButton.textContent = 'Collapse';
+                        } else {
+                            block.classList.add('restrictCodeBlockHeight');
+                            viewAllButton.textContent = 'View All';
+                        }
+                    });
+                }
             });
             resolve();
         } catch (err) {


### PR DESCRIPTION
Limit the height of the code container to 400px and display a view all button at the bottom to expand to full length.

Add "View All" button for tall code blocks

Introduce CSS styles and functionality to restrict code block height and add a "View All" button for expanding tall code blocks.

- Added `.restrictCodeBlockHeight` and `.view-all-button` styles in `app.css`.
- Updated `ai.message.js` to use `wrapCodeBlocks` for wrapping `<pre>` elements.
- Added `wrapCodeBlocks` function in `attach.copy.button.js` for better structure.
- Modified `attachCopyButton` to work with `.code-block-container`.
- Enhanced `HighlightWorkerClient` to handle tall code blocks with a "View All" button.